### PR TITLE
QiniuAdapter->getOperation() 修复domain未定义的问题

### DIFF
--- a/src/QiniuAdapter.php
+++ b/src/QiniuAdapter.php
@@ -91,7 +91,7 @@ class QiniuAdapter extends AbstractAdapter
     private function getOperation()
     {
         if ($this->operation == null) {
-            $this->operation = new Operation($this->domain);
+            $this->operation = new Operation($this->domains['default']);
         }
 
         return $this->operation;


### PR DESCRIPTION
修复获取图片信息等操作时会返回QiniuAdapter domain undefined的问题。