### PR TITLE
修复搭配使用 jquery-file-upload 不能正常上传图片的问题

### DIFF
--- a/src/QiniuAdapter.php
+++ b/src/QiniuAdapter.php
@@ -124,7 +124,7 @@ class QiniuAdapter extends AbstractAdapter
         $checkCrc = $config->get('checkCrc', false);
 
         $upload_manager = $this->getUploadManager();
-        list($ret, $error) = $upload_manager->put($token, $path, $contents, $params, $mime, $checkCrc);
+        list($ret, $error) = $upload_manager->putFile($token, $path, $contents, $params, $mime, $checkCrc);
 
         if ($error !== null) {
             $this->logQiniuError($error);


### PR DESCRIPTION
搭配 [jquery-file-upload](https://github.com/blueimp/jQuery-File-Upload) 上传后的图片类似下面这样（我原图是一张`900x900`的图）：

[http://file.kkdesign.cn/5ef8c0219d9e00cfcffd2429aba9dda02ci6973.png](http://file.kkdesign.cn/5ef8c0219d9e00cfcffd2429aba9dda02ci6973.png)

需要修改 `QiniuAdapter.php` 里的 `write` 方法，把 `$upload_manager->put` 改为 `$upload_manager->putFile`