### PR TITLE
增加对私有库的配置，修复avinfo等

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
             'secret_key'=> '',  //SecretKey
             'bucket'    => '',  //Bucket名字
             'notify_url'=> '',  //持久化处理回调地址
+            'access'    => 'public'  //空间访问控制 public 或 private
         ],
     ],
 

--- a/src/QiniuAdapter.php
+++ b/src/QiniuAdapter.php
@@ -25,6 +25,7 @@ class QiniuAdapter extends AbstractAdapter
     private $bucket = null;
     private $domains = null;
     private $notify_url = null; //持久化处理后的回调地址
+    private $access = null;
 
     private $auth = null;
     private $upload_manager = null;
@@ -35,7 +36,7 @@ class QiniuAdapter extends AbstractAdapter
 
     private $lastQetag = null;
 
-    public function __construct($access_key, $secret_key, $bucket, $domains, $notify_url = null)
+    public function __construct($access_key, $secret_key, $bucket, $domains, $notify_url = null, $access = 'public')
     {
         $this->access_key = $access_key;
         $this->secret_key = $secret_key;
@@ -46,6 +47,7 @@ class QiniuAdapter extends AbstractAdapter
         $this->setDomainPrefix('https://' . $this->domains['https'], 'https');
         $this->setDomainPrefix('http://' . $this->domains['custom'], 'custom');
         $this->notify_url = $notify_url;
+        $this->access = $access;
     }
 
     /**
@@ -97,7 +99,10 @@ class QiniuAdapter extends AbstractAdapter
     private function getOperation()
     {
         if ($this->operation == null) {
-            $this->operation = new Operation($this->domains['default']);
+            $this->operation = new Operation(
+                $this->domains['default'],
+                $this->access === 'public' ? null : $this->getAuth()
+            );
         }
 
         return $this->operation;
@@ -596,7 +601,7 @@ class QiniuAdapter extends AbstractAdapter
     {
         $operation = $this->getOperation();
 
-        list($ret, $error) = $operation->execute($path, 'avInfo');
+        list($ret, $error) = $operation->execute($path, 'avinfo');
 
         if ($error !== null) {
             $this->logQiniuError($error);

--- a/src/QiniuAdapter.php
+++ b/src/QiniuAdapter.php
@@ -565,11 +565,11 @@ class QiniuAdapter extends AbstractAdapter
      * @param bool $force
      * @return bool
      */
-    public function persistentFop($path = null, $fops = null, $pipline = null, $force = false)
+    public function persistentFop($path = null, $fops = null, $pipline = null, $force = false, $notify_url = null)
     {
         $auth = $this->getAuth();
 
-        $pfop = New PersistentFop($auth, $this->bucket, $pipline, $this->notify_url, $force);
+        $pfop = New PersistentFop($auth, $this->bucket, $pipline, is_null($notify_url) ? $this->notify_url : $notify_url, $force);
 
         list($id, $error) = $pfop->execute($path, $fops);
 

--- a/src/QiniuFilesystemServiceProvider.php
+++ b/src/QiniuFilesystemServiceProvider.php
@@ -38,7 +38,8 @@ class QiniuFilesystemServiceProvider extends ServiceProvider
                     $config['secret_key'],
                     $config['bucket'],
                     $domains,
-                    $config['notify_url'] ? $config['notify_url'] : null
+                    $config['notify_url'] ? $config['notify_url'] : null,
+                    $config['access'] ? $config['access'] : null
                 );
                 $file_system = new Filesystem($qiniu_adapter);
                 $file_system->addPlugin(new PrivateDownloadUrl());

--- a/src/QiniuStorage.php
+++ b/src/QiniuStorage.php
@@ -153,6 +153,9 @@ class QiniuStorage
     /**
      * 获取上传Token
      * @param $key
+     * @param $expires
+     * @param $policy
+     * @param $strictPolicy
      * @return bool
      */
     public function uploadToken($key = null, $expires = 3600, $policy = null, $strictPolicy = true)
@@ -236,11 +239,14 @@ class QiniuStorage
      * 执行持久化数据处理
      * @param $key
      * @param $opts
+     * @param $pipline
+     * @param $force
+     * @param $notify_url
      * @return mixed
      */
-    public function persistentFop($key, $opts)
+    public function persistentFop($key, $opts, $pipline = null, $force = false, $notify_url = null)
     {
-        return $this->storage->getDriver()->persistentFop($key, $opts);
+        return $this->storage->getDriver()->persistentFop($key, $opts, $pipline, $force, $notify_url);
     }
 
     /**


### PR DESCRIPTION
1. Fixed issue while execute avinfo, imageInfo, imagePreviewUrl  and other similar fops in a private bucket

2. Fixed issue in QiniuAdapter@avInfo() [see here](https://developer.qiniu.com/dora/api/1247/audio-and-video-metadata-information-avinfo)

3. Added rest parameters to QiniuStorage@persistentFop

4. A final chance to modify $notify_url, this could be useful if user wants to customize the notify url parameters. see QiniuAdapter@persistentFop