### PR TITLE
Revert "Update README.md"

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## 安装
 
  - ```composer require zgldh/qiniu-laravel-storage```
- - ```config/app.php``` 里面的 ```providers``` 数组， 加上一行 ```zgldh\QiniuStorage\QiniuFilesystemServiceProvider::class```
+ - ```config/app.php``` 里面的 ```providers``` 数组， 加上一行 ```zgldh\QiniuStorage\QiniuFilesystemServiceProvider```
  - ```config/filesystem.php``` 里面的 ```disks```数组加上：
 
 ```php


### PR DESCRIPTION
Reverts zgldh/qiniu-laravel-storage#32

由于我们支持PHP 5.3， 由于 5.3 里面没有 ``` ::class ``` 的用法。
所以还是写成原来的样子。 
这是 PHP 基础，我觉得没必要在此花笔墨。