### PR TITLE
手动指明Storage命名空间

### DIFF
--- a/src/QiniuFilesystemServiceProvider.php
+++ b/src/QiniuFilesystemServiceProvider.php
@@ -1,5 +1,6 @@
 <?php namespace zgldh\QiniuStorage;
 
+use Illuminate\Support\Facades\Storage;
 use League\Flysystem\Filesystem;
 use Illuminate\Support\ServiceProvider;
 use zgldh\QiniuStorage\Plugins\DownloadUrl;
@@ -23,7 +24,7 @@ class QiniuFilesystemServiceProvider extends ServiceProvider
 
     public function boot()
     {
-        \Storage::extend(
+        Storage::extend(
             'qiniu',
             function ($app, $config) {
                 if (isset($config['domains'])) {


### PR DESCRIPTION
在lumen 5.6环境下，使用\Storage会提示类不存在，所以需要把整个门面引入进来